### PR TITLE
bump com.squareup.okhttp3 version to 4.9.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -32,10 +32,10 @@ repositories {
 
 dependencies {
    implementation "com.facebook.react:react-native:+"
-    implementation "com.squareup.okhttp3:okhttp:4.2.2"
+    implementation "com.squareup.okhttp3:okhttp:4.9.0"
     implementation "com.squareup.okio:okio:2.6.0"
     implementation "com.github.franmontiel:PersistentCookieJar:v1.0.1"
-    implementation "com.squareup.okhttp3:logging-interceptor:4.2.2"
-    implementation "com.squareup.okhttp3:okhttp-urlconnection:4.2.2"
+    implementation "com.squareup.okhttp3:logging-interceptor:4.9.0"
+    implementation "com.squareup.okhttp3:okhttp-urlconnection:4.9.0"
 }
   


### PR DESCRIPTION
I noticed my app crashing on http error.
After investigating further I noticed that the crash was caused by the react-native-ssl-pinning library while it tries to log the http error.

Crash message:
```Caused by: java.lang.NoSuchMethodError: No virtual method log(ILjava/lang/String;Ljava/lang/Throwable;)V in class Lokhttp3/internal/platform/Platform; or its super classes (declaration of 'okhttp3.internal.platform.Platform' appears in /data/app/~~xxxxx==/aaa.bbb.ccc.debug-eee==/base.apk!classes3.dex)```

After incresing the com.squareup.okhttp3:okhttp version to 4.9.0 the crash was gone and I could not notice any misbehavior.